### PR TITLE
404 GH Page fix: image location issue

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -1,6 +1,11 @@
 <nav id="nav-container" class="hero-nav">
     <div id="navbar-logo">
-        <img src="../assets/images/cdm-logo.png" alt="Cdm logo" id="navbar-logo-img">
+
+        <!--   this logo can be everywhere, it will check other file location if the location gives error     -->
+        <!--   this is an ugly fix :D need help     -->
+        <img id="navbar-logo-img"
+             src="./assets/images/cdm-logo.png"
+             onerror="this.onerror=null; this.src='../assets/images/cdm-logo.png'" alt="CDM Logo">
         <div id="navbar-logo-text">
             <p>CDM</p>
             <p>INSTITUTE OF HIGHER EDUCATION</p>


### PR DESCRIPTION
Issue: #8 image going to alt content

Fix:
Based on this stackoverflow https://stackoverflow.com/questions/7995080/html-if-image-is-not-found
this will find images in the same folder, if not in the same folder, go to the outer folder 

this is not scaleable approach, might encounter this again soon :D. for now, use this.